### PR TITLE
Added hooks for ShowCaseStandalone

### DIFF
--- a/src/com/bergerkiller/bukkit/nolagg/ItemHandler.java
+++ b/src/com/bergerkiller/bukkit/nolagg/ItemHandler.java
@@ -15,6 +15,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 import com.narrowtux.showcase.Showcase;
+import com.miykeal.showCaseStandalone.ShowCaseStandalone;
 
 public class ItemHandler {
 	public static int maxItemsPerChunk;
@@ -70,6 +71,16 @@ public class ItemHandler {
 		        return Showcase.instance.getItemByDrop(item) != null;
 			} catch (Throwable t) {
 				System.out.println("[NoLagg] Showcase item verification failed, contact the authors!");
+				t.printStackTrace();
+				NoLagg.isShowcaseEnabled = false;
+			}
+                
+                } else if(NoLagg.isSCSEnabled) {
+                    try {
+                        System.out.println("[NoLagg] isSCSEnabled check:" + ShowCaseStandalone.get().isShowCaseItem(item));
+		        return ShowCaseStandalone.get().isShowCaseItem(item);
+			} catch (Throwable t) {
+				System.out.println("[NoLagg] ShowcaseStandalone item verification failed, contact the authors!");
 				t.printStackTrace();
 				NoLagg.isShowcaseEnabled = false;
 			}

--- a/src/com/bergerkiller/bukkit/nolagg/ItemHandler.java
+++ b/src/com/bergerkiller/bukkit/nolagg/ItemHandler.java
@@ -77,7 +77,6 @@ public class ItemHandler {
                 
                 } else if(NoLagg.isSCSEnabled) {
                     try {
-                        System.out.println("[NoLagg] isSCSEnabled check:" + ShowCaseStandalone.get().isShowCaseItem(item));
 		        return ShowCaseStandalone.get().isShowCaseItem(item);
 			} catch (Throwable t) {
 				System.out.println("[NoLagg] ShowcaseStandalone item verification failed, contact the authors!");

--- a/src/com/bergerkiller/bukkit/nolagg/NoLagg.java
+++ b/src/com/bergerkiller/bukkit/nolagg/NoLagg.java
@@ -45,6 +45,7 @@ public class NoLagg extends JavaPlugin {
 	public static boolean useSpawnLimits;
 	public static boolean useChunkUnloadDelay;
 	public static boolean isShowcaseEnabled = false;
+        public static boolean isSCSEnabled = false;
 	public static boolean isAddonEnabled = false;
 		
 	private static Logger logger = Logger.getLogger("Minecraft");
@@ -74,6 +75,9 @@ public class NoLagg extends JavaPlugin {
 				if (getServer().getPluginManager().isPluginEnabled("Showcase")) {
 					isShowcaseEnabled = true;
 				}
+                                if (getServer().getPluginManager().isPluginEnabled("ShowCaseStandalone")){
+                                        isSCSEnabled = true;
+                                }
 			}
 		}, 1);
 		if (getServer().getPluginManager().isPluginEnabled("NoLaggChunks")) {


### PR DESCRIPTION
I added an additional exemption for ShowcaseStandalone, which operates very much like Showcase.  ShowcaseStandalone is hosted at http://dev.bukkit.org/server-mods/scs/.

I'm waiting the main dev to upload the updated jar that includes the hook used here, but if you need it in the meantime, you can find it at http://dl.dropbox.com/u/122940/ShowCaseStandalone.jar
