### PR TITLE
Fixes Issue #19 Unobtainable items being dropped.

### DIFF
--- a/src/com/bergerkiller/bukkit/nolagg/itemstacker/WorldStackFormer.java
+++ b/src/com/bergerkiller/bukkit/nolagg/itemstacker/WorldStackFormer.java
@@ -116,7 +116,7 @@ public class WorldStackFormer implements Runnable {
 							continue;
 						if (nearitem.itemStack == null)
 							continue;
-						if (ItemUtil.transfer(nearitem.itemStack, item.itemStack, Integer.MAX_VALUE) > 0) {
+						if (ItemUtil.transfer(nearitem.itemStack.cloneItemStack(), item.itemStack, Integer.MAX_VALUE) > 0) {
 							if (nearitem.itemStack.count == 0) {
 								kill(nearitem);
 								// respawn item


### PR DESCRIPTION
This fixes Issue #19.  I was able to replicate it very easily when installed with mcmmo to get multiple drops.  As soon as I cloned the item, unobtainable items stopped appearing.
